### PR TITLE
Feat: Accept order-like items in order details messages

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nyaruka/goflow/flows/resumes"
 	"github.com/nyaruka/goflow/flows/triggers"
 	"github.com/nyaruka/goflow/services/classification/wit"
+	"github.com/nyaruka/goflow/services/meta"
 	"github.com/nyaruka/goflow/services/webhooks"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/pkg/errors"
@@ -87,7 +88,8 @@ func main() {
 
 func createEngine(witToken string) flows.Engine {
 	builder := engine.NewBuilder().
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-runner"}, 10000))
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-runner"}, 10000)).
+		WithMetaServiceFactory(meta.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-runner"}, 10000, flows.WhatsAppSystemUserToken, "https://graph.facebook.com/v21.0"))
 
 	if witToken != "" {
 		builder.WithClassificationServiceFactory(func(session flows.Session, classifier *flows.Classifier) (flows.ClassificationService, error) {

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nyaruka/goflow/services/brain"
 	"github.com/nyaruka/goflow/services/classification/wit"
 	"github.com/nyaruka/goflow/services/email/smtp"
+	"github.com/nyaruka/goflow/services/meta"
 	"github.com/nyaruka/goflow/services/webhooks"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
@@ -239,6 +240,7 @@ func testActionType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 				return dtone.NewService(http.DefaultClient, nil, "nyaruka", "123456789"), nil
 			}).
 			WithBrainServiceFactory(brain.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-testing"}, 10000, "token", "http://127.0.0.1:49994")).
+			WithMetaServiceFactory(meta.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-testing"}, 10000, "system-user-token", "http://127.0.0.1:49994")).
 			Build()
 
 		// create session

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/goflow/utils/smtpx"
+	"github.com/shopspring/decimal"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -217,6 +218,25 @@ func testActionType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 					"audio/mp3:http://s3.amazon.com/bucket/test.mp3",
 				},
 			)
+			itemPrice, _ := decimal.NewFromString("20.99")
+			msg.SetOrder(&flows.Order{
+				CatalogID: "CATALOG_ID",
+				Text:      "order msg text",
+				ProductItems: []flows.ProductItem{
+					{
+						Currency:          "BRL",
+						ItemPrice:         itemPrice,
+						ProductRetailerID: "RETAILER_ID_1",
+						Quantity:          1,
+					},
+					{
+						Currency:          "BRL",
+						ItemPrice:         itemPrice,
+						ProductRetailerID: "RETAILER_ID_2",
+						Quantity:          1,
+					},
+				},
+			})
 			trigger = triggers.NewBuilder(env, flow.Reference(), contact).Msg(msg).Build()
 			ignoreEventCount = 1 // need to ignore the msg_received event this trigger creates
 		}

--- a/flows/actions/send_wpp_message.go
+++ b/flows/actions/send_wpp_message.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -179,91 +180,10 @@ func (a *SendWppMsgAction) Execute(run flows.FlowRun, step flows.Step, logModifi
 			return nil
 		}
 
-		tempOrderItems := []map[string]interface{}{}
-		err := json.Unmarshal([]byte(evaluatedOrderItems), &tempOrderItems)
+		orderItems, err := parseOrderItems(a, run, evaluatedOrderItems, logEvent)
 		if err != nil {
-			logEvent(events.NewErrorf("error unmarshalling order items: %v", err))
+			logEvent(events.NewErrorf("error parsing order items: %v", err))
 			return nil
-		}
-
-		if len(tempOrderItems) == 0 {
-			logEvent(events.NewErrorf("order items evaluated to empty array"))
-			return nil
-		}
-
-		orderItems := []flows.MessageOrderItem{}
-		for _, item := range tempOrderItems {
-			if item["quantity"] == nil {
-				logEvent(events.NewErrorf("order item quantity is nil"))
-				return nil
-			}
-			convertedQuantity, isFloat := item["quantity"].(float64)
-			if !isFloat {
-				logEvent(events.NewErrorf("error reading order item quantity: %v", item["quantity"]))
-				return nil
-			}
-
-			if item["amount"] == nil {
-				logEvent(events.NewErrorf("order item amount is required"))
-				return nil
-			}
-			var convertedAmount float64
-			var convertedOffset float64
-			itemAmount, ok := item["amount"].(map[string]interface{})
-			if !ok {
-				logEvent(events.NewErrorf("error reading order item amount: %v", item["amount"]))
-				return nil
-			}
-			convertedAmount, isFloat = itemAmount["value"].(float64)
-			if !isFloat {
-				logEvent(events.NewErrorf("error reading order item amount: %v", itemAmount["value"]))
-				return nil
-			}
-
-			convertedOffset, isFloat = itemAmount["offset"].(float64)
-			if !isFloat {
-				logEvent(events.NewErrorf("error reading order item amount offset: %v", itemAmount["offset"]))
-				return nil
-			}
-
-			orderItem := flows.MessageOrderItem{
-				RetailerID: item["retailer_id"].(string),
-				Name:       item["name"].(string),
-				Quantity:   int(convertedQuantity),
-				Amount: flows.MessageOrderAmountWithOffset{
-					Value:  int(convertedAmount),
-					Offset: int(convertedOffset),
-				},
-			}
-
-			if item["sale_amount"] != nil {
-				itemSaleAmount, ok := item["sale_amount"].(map[string]interface{})
-				if !ok {
-					logEvent(events.NewErrorf("error reading order item sale amount: %v", item["sale_amount"]))
-					return nil
-				}
-				convertedSaleAmount, isFloat := itemSaleAmount["value"].(float64)
-				if !isFloat {
-					logEvent(events.NewErrorf("error converting order item sale amount %s: %v", itemSaleAmount["value"], err))
-					return nil
-				}
-
-				convertedSaleAmountOffset, isFloat := itemSaleAmount["offset"].(float64)
-				if !isFloat {
-					logEvent(events.NewErrorf("error converting order item sale amount offset %s: %v", itemSaleAmount["offset"], err))
-					return nil
-				}
-
-				if convertedSaleAmount > 0 {
-					orderItem.SaleAmount = &flows.MessageOrderAmountWithOffset{
-						Value:  int(convertedSaleAmount),
-						Offset: int(convertedSaleAmountOffset),
-					}
-				}
-
-			}
-
-			orderItems = append(orderItems, orderItem)
 		}
 
 		evaluatedOrderTax, _ := run.EvaluateTemplate(a.OrderDetails.Tax.Value)
@@ -383,4 +303,148 @@ func (a *SendWppMsgAction) Execute(run flows.FlowRun, step flows.Step, logModifi
 	}
 
 	return nil
+}
+
+func parseOrderItems(a *SendWppMsgAction, run flows.FlowRun, evaluatedOrderItems string, logEvent flows.EventCallback) ([]flows.MessageOrderItem, error) {
+	tempOrderItems := []map[string]interface{}{}
+	// try to parse it as an array of items
+	err := json.Unmarshal([]byte(evaluatedOrderItems), &tempOrderItems)
+	if err != nil {
+		// try to parse it as an order-like structure
+		order := flows.Order{}
+		err = json.Unmarshal([]byte(evaluatedOrderItems), &order)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling order items: %v", err)
+		}
+
+		tempOrderItems, err = searchMetaForOrderItems(a, run, order, logEvent)
+		if err != nil {
+			return nil, fmt.Errorf("error searching for order items: %v", err)
+		}
+	}
+
+	if len(tempOrderItems) == 0 {
+		return nil, fmt.Errorf("order items evaluated to empty array")
+	}
+
+	orderItems := []flows.MessageOrderItem{}
+	for _, item := range tempOrderItems {
+		if item["quantity"] == nil {
+			return nil, fmt.Errorf("order item quantity is nil")
+		}
+		convertedQuantity, isFloat := item["quantity"].(float64)
+		if !isFloat {
+			return nil, fmt.Errorf("error reading order item quantity: %v", item["quantity"])
+		}
+
+		if item["amount"] == nil {
+			return nil, fmt.Errorf("order item amount is required")
+		}
+		var convertedAmount float64
+		var convertedOffset float64
+		itemAmount, ok := item["amount"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("error reading order item amount: %v", item["amount"])
+		}
+		convertedAmount, isFloat = itemAmount["value"].(float64)
+		if !isFloat {
+			return nil, fmt.Errorf("error reading order item amount: %v", itemAmount["value"])
+		}
+
+		convertedOffset, isFloat = itemAmount["offset"].(float64)
+		if !isFloat {
+			return nil, fmt.Errorf("error reading order item amount offset: %v", itemAmount["offset"])
+		}
+
+		orderItem := flows.MessageOrderItem{
+			RetailerID: item["retailer_id"].(string),
+			Name:       item["name"].(string),
+			Quantity:   int(convertedQuantity),
+			Amount: flows.MessageOrderAmountWithOffset{
+				Value:  int(convertedAmount),
+				Offset: int(convertedOffset),
+			},
+		}
+
+		if item["sale_amount"] != nil {
+			itemSaleAmount, ok := item["sale_amount"].(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("error reading order item sale amount: %v", item["sale_amount"])
+			}
+			convertedSaleAmount, isFloat := itemSaleAmount["value"].(float64)
+			if !isFloat {
+				return nil, fmt.Errorf("error converting order item sale amount %s: %v", itemSaleAmount["value"], err)
+			}
+
+			convertedSaleAmountOffset, isFloat := itemSaleAmount["offset"].(float64)
+			if !isFloat {
+				return nil, fmt.Errorf("error converting order item sale amount offset %s: %v", itemSaleAmount["offset"], err)
+			}
+
+			if convertedSaleAmount > 0 {
+				orderItem.SaleAmount = &flows.MessageOrderAmountWithOffset{
+					Value:  int(convertedSaleAmount),
+					Offset: int(convertedSaleAmountOffset),
+				}
+			}
+
+		}
+
+		orderItems = append(orderItems, orderItem)
+	}
+
+	return orderItems, nil
+}
+
+func searchMetaForOrderItems(a *SendWppMsgAction, run flows.FlowRun, order flows.Order, logEvent flows.EventCallback) ([]map[string]interface{}, error) {
+	svc, err := run.Session().Engine().Services().Meta(run.Session())
+	if err != nil {
+		return nil, err
+	}
+
+	httpLogger := &flows.HTTPLogger{}
+	responseJSON, err := svc.OrderProductsSearch(order, httpLogger.Log)
+
+	if len(httpLogger.Logs) > 0 {
+		logEvent(events.NewMetaCalled(httpLogger.Logs))
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if responseJSON != nil {
+		var response struct {
+			Data []struct {
+				RetailerID string `json:"retailer_id"`
+				Name       string `json:"name"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(responseJSON, &response)
+		if err != nil {
+			return nil, err
+		}
+
+		// mount the order items with the item name on it, mapped by the retailer id
+		orderItems := []map[string]interface{}{}
+		for _, product := range response.Data {
+			existingItem := order.FindProductByRetailerID(product.RetailerID)
+			if existingItem != nil {
+				amount, _ := existingItem.ItemPrice.Float64()
+				orderItems = append(orderItems, map[string]interface{}{
+					"retailer_id": existingItem.ProductRetailerID,
+					"name":        product.Name,
+					"quantity":    float64(existingItem.Quantity),
+					"amount": map[string]interface{}{
+						"value":  amount * 100,
+						"offset": float64(100),
+					},
+				})
+			}
+		}
+
+		return orderItems, nil
+	}
+
+	return nil, fmt.Errorf("unknown error fetching products")
 }

--- a/flows/actions/testdata/send_whatsapp_msg.json
+++ b/flows/actions/testdata/send_whatsapp_msg.json
@@ -201,7 +201,7 @@
         }
     },
     {
-        "description": "WhatsApp Order Details message",
+        "description": "WhatsApp Order Details message with array item list",
         "action": {
             "type": "send_whatsapp_msg",
             "uuid": "c67969d6-f400-4b5e-bb7c-e45115cd3aa4",
@@ -304,6 +304,143 @@
                         },
                         "reference_id": "123456",
                         "total_amount": 1699
+                    }
+                }
+            }
+        ],
+        "inspection": {
+            "dependencies": [],
+            "issues": [],
+            "results": [],
+            "waiting_exits": [],
+            "parent_refs": []
+        }
+    },
+    {
+        "description": "WhatsApp Order Details message with order-like item list",
+        "http_mocks": {
+            "http://127.0.0.1:49994/CATALOG_ID/products?access_token=system-user-token&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22123%22%7D%7D%5D%7D%5D%7D&summary=true": [
+                {
+                    "status": 200,
+                    "body": "{\"data\":[{\"retailer_id\":\"123\",\"name\":\"item 1\",\"id\":\"456\"}],\"summary\":{\"total_count\":1}}"
+                }
+            ]
+        },
+        "action": {
+            "type": "send_whatsapp_msg",
+            "uuid": "c67969d6-f400-4b5e-bb7c-e45115cd3aa4",
+            "header_type": "media",
+            "attachment": "image/jpeg:https://foo.bar/image.jpg",
+            "footer": "footer",
+            "interaction_type": "order_details",
+            "text": "Hi there!",
+            "button_text": "Button text",
+            "order_details": {
+                "reference_id": "123456",
+                "item_list": "{\"catalog_id\":\"CATALOG_ID\",\"text\":\"msg text\",\"product_items\":[{\"product_retailer_id\":\"123\",\"quantity\":1,\"item_price\":20.99,\"currency\":\"BRL\"}]}",
+                "tax": {
+                    "value": "2,99",
+                    "description": "tax"
+                },
+                "shipping": {
+                    "value": "9.99",
+                    "description": "shipping"
+                },
+                "discount": {
+                    "value": "5.99",
+                    "description": "discount"
+                },
+                "payment_settings": {
+                    "type": "digital-goods",
+                    "payment_link": "https://www.foo.bar",
+                    "pix_config": {
+                        "key": "key",
+                        "key_type": "key type",
+                        "merchant_name": "merchant name",
+                        "code": "code"
+                    }
+                }
+            }
+        },
+        "localization": {},
+        "events": [
+            {
+                "type": "meta_called",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "step_uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
+                "http_logs": [
+                    {
+                        "url": "http://127.0.0.1:49994/CATALOG_ID/products?access_token=****************&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22123%22%7D%7D%5D%7D%5D%7D&summary=true",
+                        "status_code": 200,
+                        "status": "success",
+                        "request": "GET /CATALOG_ID/products?access_token=****************&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22123%22%7D%7D%5D%7D%5D%7D&summary=true HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                        "response": "HTTP/1.0 200 OK\r\nContent-Length: 87\r\n\r\n{\"data\":[{\"retailer_id\":\"123\",\"name\":\"item 1\",\"id\":\"456\"}],\"summary\":{\"total_count\":1}}",
+                        "elapsed_ms": 0,
+                        "retries": 0,
+                        "created_on": "2018-10-18T14:20:30.000123456Z"
+                    }
+                ]
+            },
+            {
+                "type": "msg_wpp_created",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "step_uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
+                "msg": {
+                    "uuid": "9688d21d-95aa-4bed-afc7-f31b35731a3d",
+                    "urn": "tel:+12065551212?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=123",
+                    "channel": {
+                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
+                        "name": "My Android Phone"
+                    },
+                    "text": "Hi there!",
+                    "footer": "footer",
+                    "header_type": "media",
+                    "attachments": [
+                        "image/jpeg:https://foo.bar/image.jpg"
+                    ],
+                    "interaction_type": "order_details",
+                    "cta_message": {},
+                    "list_message": {},
+                    "flow_message": {},
+                    "order_details_message": {
+                        "order": {
+                            "discount": {
+                                "description": "discount",
+                                "value": 599
+                            },
+                            "items": [
+                                {
+                                    "amount": {
+                                        "offset": 100,
+                                        "value": 2099
+                                    },
+                                    "name": "item 1",
+                                    "quantity": 1,
+                                    "retailer_id": "123"
+                                }
+                            ],
+                            "shipping": {
+                                "description": "shipping",
+                                "value": 999
+                            },
+                            "subtotal": 2099,
+                            "tax": {
+                                "description": "tax",
+                                "value": 299
+                            }
+                        },
+                        "payment_settings": {
+                            "payment_link": "https://www.foo.bar",
+                            "pix_config": {
+                                "code": "code",
+                                "key": "key",
+                                "key_type": "key type",
+                                "merchant_name": "merchant name"
+                            },
+                            "type": "digital-goods"
+                        },
+                        "reference_id": "123456",
+                        "total_amount": 2798
                     }
                 }
             }

--- a/flows/actions/testdata/send_whatsapp_msg.json
+++ b/flows/actions/testdata/send_whatsapp_msg.json
@@ -319,10 +319,10 @@
     {
         "description": "WhatsApp Order Details message with order-like item list",
         "http_mocks": {
-            "http://127.0.0.1:49994/CATALOG_ID/products?access_token=system-user-token&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22123%22%7D%7D%5D%7D%5D%7D&summary=true": [
+            "http://127.0.0.1:49994/CATALOG_ID/products?access_token=system-user-token&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22RETAILER_ID_1%22%7D%7D%5D%7D%2C%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22RETAILER_ID_2%22%7D%7D%5D%7D%5D%7D&summary=true": [
                 {
                     "status": 200,
-                    "body": "{\"data\":[{\"retailer_id\":\"123\",\"name\":\"item 1\",\"id\":\"456\"}],\"summary\":{\"total_count\":1}}"
+                    "body": "{\"data\":[{\"retailer_id\":\"RETAILER_ID_1\",\"name\":\"item 1\",\"id\":\"456\"}],\"summary\":{\"total_count\":1}}"
                 }
             ]
         },
@@ -337,7 +337,7 @@
             "button_text": "Button text",
             "order_details": {
                 "reference_id": "123456",
-                "item_list": "{\"catalog_id\":\"CATALOG_ID\",\"text\":\"msg text\",\"product_items\":[{\"product_retailer_id\":\"123\",\"quantity\":1,\"item_price\":20.99,\"currency\":\"BRL\"}]}",
+                "item_list": "@input.order",
                 "tax": {
                     "value": "2,99",
                     "description": "tax"
@@ -370,16 +370,22 @@
                 "step_uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
                 "http_logs": [
                     {
-                        "url": "http://127.0.0.1:49994/CATALOG_ID/products?access_token=****************&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22123%22%7D%7D%5D%7D%5D%7D&summary=true",
+                        "url": "http://127.0.0.1:49994/CATALOG_ID/products?access_token=****************&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22RETAILER_ID_1%22%7D%7D%5D%7D%2C%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22RETAILER_ID_2%22%7D%7D%5D%7D%5D%7D&summary=true",
                         "status_code": 200,
                         "status": "success",
-                        "request": "GET /CATALOG_ID/products?access_token=****************&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22123%22%7D%7D%5D%7D%5D%7D&summary=true HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
-                        "response": "HTTP/1.0 200 OK\r\nContent-Length: 87\r\n\r\n{\"data\":[{\"retailer_id\":\"123\",\"name\":\"item 1\",\"id\":\"456\"}],\"summary\":{\"total_count\":1}}",
+                        "request": "GET /CATALOG_ID/products?access_token=****************&fields=%5B%22category%22%2C%22name%22%2C%22retailer_id%22%2C%22availability%22%5D&filter=%7B%22or%22%3A%5B%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22RETAILER_ID_1%22%7D%7D%5D%7D%2C%7B%22and%22%3A%5B%7B%22retailer_id%22%3A%7B%22i_contains%22%3A%22RETAILER_ID_2%22%7D%7D%5D%7D%5D%7D&summary=true HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                        "response": "HTTP/1.0 200 OK\r\nContent-Length: 97\r\n\r\n{\"data\":[{\"retailer_id\":\"RETAILER_ID_1\",\"name\":\"item 1\",\"id\":\"456\"}],\"summary\":{\"total_count\":1}}",
                         "elapsed_ms": 0,
                         "retries": 0,
                         "created_on": "2018-10-18T14:20:30.000123456Z"
                     }
                 ]
+            },
+            {
+                "type": "error",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "step_uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
+                "text": "not all provided order items were found in Meta, requested 2, found 1"
             },
             {
                 "type": "msg_wpp_created",
@@ -416,7 +422,7 @@
                                     },
                                     "name": "item 1",
                                     "quantity": 1,
-                                    "retailer_id": "123"
+                                    "retailer_id": "RETAILER_ID_1"
                                 }
                             ],
                             "shipping": {

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -123,6 +123,12 @@ func (b *Builder) WithBrainServiceFactory(f BrainServiceFactory) *Builder {
 	return b
 }
 
+// WithMetaServiceFactory sets the meta service factory
+func (b *Builder) WithMetaServiceFactory(f MetaServiceFactory) *Builder {
+	b.eng.services.meta = f
+	return b
+}
+
 // WithMaxStepsPerSprint sets the maximum number of steps allowed in a single sprint
 func (b *Builder) WithMaxStepsPerSprint(max int) *Builder {
 	b.eng.maxStepsPerSprint = max

--- a/flows/engine/engine_test.go
+++ b/flows/engine/engine_test.go
@@ -34,6 +34,8 @@ func TestBuilder(t *testing.T) {
 	assert.EqualError(t, err, "no org context service factory configured")
 	_, err = eng.Services().Brain(nil)
 	assert.EqualError(t, err, "no brain service factory configured")
+	_, err = eng.Services().Meta(nil)
+	assert.EqualError(t, err, "no meta service factory configured")
 
 	// include a webhook service
 	webhookSvc := webhooks.NewService(&http.Client{}, nil, nil, map[string]string{"User-Agent": "goflow"}, 1000)

--- a/flows/engine/services.go
+++ b/flows/engine/services.go
@@ -34,6 +34,8 @@ type MsgCatalogServiceFactory func(flows.Session, *flows.MsgCatalog) (flows.MsgC
 
 type OrgContextServiceFactory func(flows.Session, *flows.OrgContext) (flows.OrgContextService, error)
 
+type MetaServiceFactory func(flows.Session) (flows.MetaService, error)
+
 type services struct {
 	email           EmailServiceFactory
 	webhook         WebhookServiceFactory
@@ -45,6 +47,7 @@ type services struct {
 	msgCatalog      MsgCatalogServiceFactory
 	orgContext      OrgContextServiceFactory
 	brain           BrainServiceFactory
+	meta            MetaServiceFactory
 }
 
 func newEmptyServices() *services {
@@ -78,6 +81,9 @@ func newEmptyServices() *services {
 		},
 		brain: func(flows.Session) (flows.BrainService, error) {
 			return nil, errors.New("no brain service factory configured")
+		},
+		meta: func(flows.Session) (flows.MetaService, error) {
+			return nil, errors.New("no meta service factory configured")
 		},
 	}
 }
@@ -120,4 +126,8 @@ func (s *services) OrgContext(session flows.Session, context *flows.OrgContext) 
 
 func (s *services) Brain(session flows.Session) (flows.BrainService, error) {
 	return s.brain(session)
+}
+
+func (s *services) Meta(session flows.Session) (flows.MetaService, error) {
+	return s.meta(session)
 }

--- a/flows/engine/services_test.go
+++ b/flows/engine/services_test.go
@@ -34,4 +34,8 @@ func TestEmptyServices(t *testing.T) {
 	orgContextSvc, err := eng.Services().OrgContext(nil, nil)
 	assert.EqualError(t, err, "no org context service factory configured")
 	assert.Nil(t, orgContextSvc)
+
+	metaSvc, err := eng.Services().Meta(nil)
+	assert.EqualError(t, err, "no meta service factory configured")
+	assert.Nil(t, metaSvc)
 }

--- a/flows/events/meta_called.go
+++ b/flows/events/meta_called.go
@@ -21,7 +21,7 @@ const TypeMetaCalled string = "meta_called"
 //         "url": "https://graph.facebook.com/v21.0/me",
 //         "status": "success",
 //         "request": "GET /me HTTP/1.1",
-//         "response": "HTTP/1.1 200 OK\r\n\r\n{\"status\":"ok"}",
+//         "response": "HTTP/1.1 200 OK\r\n\r\n{\"status\":\"ok\"}",
 //         "created_on": "2006-01-02T15:04:05Z",
 //         "elapsed_ms": 123
 //       }

--- a/flows/events/meta_called.go
+++ b/flows/events/meta_called.go
@@ -1,0 +1,43 @@
+package events
+
+import (
+	"github.com/nyaruka/goflow/flows"
+)
+
+func init() {
+	registerType(TypeMetaCalled, func() flows.Event { return &MetaCalledEvent{} })
+}
+
+// TypeMetaCalled is our type for calling meta services
+const TypeMetaCalled string = "meta_called"
+
+// MetaCalledEvent events are created when a meta service is called.
+//
+//   {
+//     "type": "meta_called",
+//     "created_on": "2006-01-02T15:04:05Z",
+//     "http_logs": [
+//       {
+//         "url": "https://graph.facebook.com/v21.0/me",
+//         "status": "success",
+//         "request": "GET /me HTTP/1.1",
+//         "response": "HTTP/1.1 200 OK\r\n\r\n{\"status\":"ok"}",
+//         "created_on": "2006-01-02T15:04:05Z",
+//         "elapsed_ms": 123
+//       }
+//     ]
+//   }
+//
+// @event meta_called
+type MetaCalledEvent struct {
+	baseEvent
+	HTTPLogs []*flows.HTTPLog `json:"http_logs"`
+}
+
+// NewClassifierCalled returns a service called event for a classifier
+func NewMetaCalled(httpLogs []*flows.HTTPLog) *MetaCalledEvent {
+	return &MetaCalledEvent{
+		baseEvent: newBaseEvent(TypeMetaCalled),
+		HTTPLogs:  httpLogs,
+	}
+}

--- a/flows/order.go
+++ b/flows/order.go
@@ -75,3 +75,13 @@ func (o *Order) MarshalJSON() ([]byte, error) {
 
 	return jsonx.Marshal(oe)
 }
+
+func (o *Order) FindProductByRetailerID(retailerID string) *ProductItem {
+	for _, p := range o.ProductItems {
+		if p.ProductRetailerID == retailerID {
+			return &p
+		}
+	}
+
+	return nil
+}

--- a/flows/services.go
+++ b/flows/services.go
@@ -13,6 +13,12 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+var WhatsAppSystemUserToken string
+
+func SetWhatsAppSystemUserToken(t string) {
+	WhatsAppSystemUserToken = t
+}
+
 // Services groups together interfaces for several services whose implementation is provided outside of the flow engine.
 type Services interface {
 	Email(Session) (EmailService, error)
@@ -25,6 +31,7 @@ type Services interface {
 	WeniGPT(Session) (WeniGPTService, error)
 	MsgCatalog(Session, *MsgCatalog) (MsgCatalogService, error)
 	OrgContext(Session, *OrgContext) (OrgContextService, error)
+	Meta(Session) (MetaService, error)
 }
 
 // EmailService provides email functionality to the engine
@@ -59,6 +66,11 @@ type WebhookCall struct {
 // WebhookService provides webhook functionality to the engine
 type WebhookService interface {
 	Call(session Session, request *http.Request) (*WebhookCall, error)
+}
+
+// MetaService provides standardized Meta requests in the engine
+type MetaService interface {
+	OrderProductsSearch(order Order, logHTTP HTTPLogCallback) ([]byte, error)
 }
 
 // ExtractedIntent models an intent match

--- a/services/meta/service.go
+++ b/services/meta/service.go
@@ -1,0 +1,133 @@
+package meta
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/engine"
+	"github.com/nyaruka/goflow/services/webhooks"
+	"github.com/nyaruka/goflow/utils"
+)
+
+type service struct {
+	httpClient      *http.Client
+	httpRetries     *httpx.RetryConfig
+	httpAccess      *httpx.AccessConfig
+	defaultHeaders  map[string]string
+	maxBodyBytes    int
+	redactor        utils.Redactor
+	systemUserToken string
+	url             string
+}
+
+// NewServiceFactory creates a new meta service factory
+func NewServiceFactory(httpClient *http.Client, httpRetries *httpx.RetryConfig, httpAccess *httpx.AccessConfig, defaultHeaders map[string]string, maxBodyBytes int, systemUserToken string, url string) engine.MetaServiceFactory {
+	return func(flows.Session) (flows.MetaService, error) {
+		return NewService(httpClient, httpRetries, httpAccess, defaultHeaders, maxBodyBytes, systemUserToken, url), nil
+	}
+}
+
+// NewService creates a new default meta service
+func NewService(httpClient *http.Client, httpRetries *httpx.RetryConfig, httpAccess *httpx.AccessConfig, defaultHeaders map[string]string, maxBodyBytes int, systemUserToken string, url string) flows.MetaService {
+	return &service{
+		httpClient:      httpClient,
+		httpRetries:     httpRetries,
+		httpAccess:      httpAccess,
+		defaultHeaders:  defaultHeaders,
+		maxBodyBytes:    maxBodyBytes,
+		redactor:        utils.NewRedactor(flows.RedactionMask, systemUserToken),
+		url:             url,
+		systemUserToken: systemUserToken,
+	}
+}
+
+// Filter represents the structure of the filter for the Meta products API request
+type Filter struct {
+	Or []OrCondition `json:"or"`
+}
+
+// OrCondition represents an OR condition
+type OrCondition struct {
+	And []AndCondition `json:"and"`
+}
+
+// AndCondition represents an AND condition
+type AndCondition struct {
+	RetailerID   map[string]string `json:"retailer_id,omitempty"`
+	Availability map[string]string `json:"availability,omitempty"`
+	Visibility   map[string]string `json:"visibility,omitempty"`
+}
+
+// OrderProductsSearch searches for products in a catalog based on the order items
+func (s *service) OrderProductsSearch(order flows.Order, logHTTP flows.HTTPLogCallback) ([]byte, error) {
+	filter, err := createFilter(order.ProductItems)
+	if err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	params.Add("fields", "[\"category\",\"name\",\"retailer_id\",\"availability\"]")
+	params.Add("summary", "true")
+	params.Add("access_token", s.systemUserToken)
+	params.Add("filter", filter)
+
+	url := fmt.Sprintf("%s/%s/products?%s", s.url, order.CatalogID, params.Encode())
+
+	request, err := httpx.NewRequest("GET", url, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// set any headers with defaults
+	for k, v := range s.defaultHeaders {
+		if request.Header.Get(k) == "" {
+			request.Header.Set(k, v)
+		}
+	}
+
+	trace, err := httpx.DoTrace(s.httpClient, request, s.httpRetries, s.httpAccess, s.maxBodyBytes)
+	if trace != nil {
+		logHTTP(flows.NewHTTPLog(trace, flows.HTTPStatusFromCode, s.redactor))
+
+		// throw away any error that happened prior to getting a response.. these will be surfaced to the user
+		// as connection_error status on the response
+		if trace.Response == nil {
+			return nil, err
+		}
+
+		var responseJSON []byte
+		if len(trace.ResponseBody) > 0 {
+			responseJSON, _ = webhooks.ExtractJSON(trace.ResponseBody)
+		}
+
+		return responseJSON, err
+	}
+
+	return nil, err
+}
+
+func createFilter(orderitems []flows.ProductItem) (string, error) {
+	var filter Filter
+
+	for _, item := range orderitems {
+		andCondition := []AndCondition{
+			{
+				RetailerID: map[string]string{"i_contains": item.ProductRetailerID},
+			},
+		}
+		filter.Or = append(filter.Or, OrCondition{And: andCondition})
+	}
+
+	filterJSON, err := json.Marshal(filter)
+	if err != nil {
+		return "", err
+	}
+
+	return string(filterJSON), nil
+}
+
+var _ flows.MetaService = (*service)(nil)

--- a/services/webhooks/service.go
+++ b/services/webhooks/service.go
@@ -21,12 +21,6 @@ type service struct {
 	maxBodyBytes   int
 }
 
-var whatsAppSystemUserToken string
-
-func SetWhatsAppSystemUserToken(t string) {
-	whatsAppSystemUserToken = t
-}
-
 // NewServiceFactory creates a new webhook service factory
 func NewServiceFactory(httpClient *http.Client, httpRetries *httpx.RetryConfig, httpAccess *httpx.AccessConfig, defaultHeaders map[string]string, maxBodyBytes int) engine.WebhookServiceFactory {
 	return func(flows.Session) (flows.WebhookService, error) {
@@ -61,7 +55,7 @@ func (s *service) Call(session flows.Session, request *http.Request) (*flows.Web
 
 	// If we have a system user token, add it to the headers
 	if request.Header.Get("X-Weni-Whatsapp-Token") != "" {
-		request.Header.Set("Authorization", "Bearer "+whatsAppSystemUserToken)
+		request.Header.Set("Authorization", "Bearer "+flows.WhatsAppSystemUserToken)
 		request.Header.Del("X-Weni-Whatsapp-Token")
 	}
 

--- a/test/engine.go
+++ b/test/engine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/services/brain"
+	"github.com/nyaruka/goflow/services/meta"
 	"github.com/nyaruka/goflow/services/webhooks"
 	"github.com/nyaruka/goflow/services/wenigpt"
 
@@ -29,6 +30,7 @@ func NewEngine() flows.Engine {
 		WithWebhookServiceFactory(webhooks.NewServiceFactory(http.DefaultClient, retries, nil, map[string]string{"User-Agent": "goflow-testing"}, 10000)).
 		WithWeniGPTServiceFactory(wenigpt.NewServiceFactory(http.DefaultClient, retries, nil, map[string]string{"User-Agent": "goflow-testing"}, 10000, "token", "http://127.0.0.1:49994")).
 		WithBrainServiceFactory(brain.NewServiceFactory(http.DefaultClient, retries, nil, map[string]string{"User-Agent": "goflow-testing"}, 10000, "token", "http://127.0.0.1:49994")).
+		WithMetaServiceFactory(meta.NewServiceFactory(http.DefaultClient, retries, nil, map[string]string{"User-Agent": "goflow-testing"}, 10000, "system-user-token", "http://127.0.0.1:49994")).
 		WithClassificationServiceFactory(func(s flows.Session, c *flows.Classifier) (flows.ClassificationService, error) {
 			return newClassificationService(c), nil
 		}).

--- a/test/runner_test.go
+++ b/test/runner_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nyaruka/goflow/flows/triggers"
 	"github.com/nyaruka/goflow/services/airtime/dtone"
 	"github.com/nyaruka/goflow/services/email/smtp"
+	"github.com/nyaruka/goflow/services/meta"
 	"github.com/nyaruka/goflow/services/webhooks"
 	"github.com/nyaruka/goflow/utils/smtpx"
 
@@ -119,6 +120,7 @@ func runFlow(assetsPath string, rawTrigger json.RawMessage, rawResumes []json.Ra
 			return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io", nil)
 		}).
 		WithWebhookServiceFactory(webhooks.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-testing"}, 100000)).
+		WithMetaServiceFactory(meta.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-testing"}, 100000, "system-user-token", "http://127.0.0.1:49994")).
 		WithClassificationServiceFactory(func(s flows.Session, c *flows.Classifier) (flows.ClassificationService, error) {
 			return newClassificationService(c), nil
 		}).


### PR DESCRIPTION
- Created a new meta service to be used in product search and future meta related requests
- Refactored order details item parse to continue allowing array-like item list and also now allow order-like item list