### PR TITLE
feat: add currency field to ProductRetailerInfo struct

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.18.1
+----------
+ * feat: add currency field to ProductRetailerInfo struct
+
 1.18.0
 ----------
  * feat: add ProductEntry and ProductRetailerInfo types for enhanced product data handling in flows

--- a/flows/services.go
+++ b/flows/services.go
@@ -110,6 +110,7 @@ type ProductRetailerInfo struct {
 	RetailerID  string `json:"retailer_id,omitempty"` // sku
 	Price       string `json:"price,omitempty"`
 	SalePrice   string `json:"sale_price,omitempty"`
+	Currency    string `json:"currency,omitempty"`
 	Image       string `json:"image,omitempty"`
 	Description string `json:"description,omitempty"`
 	SellerID    string `json:"seller_id,omitempty"`

--- a/flows/services_test.go
+++ b/flows/services_test.go
@@ -109,6 +109,7 @@ func TestProductEntry(t *testing.T) {
 				RetailerID:  "sku_123",
 				Price:       "10.00",
 				SalePrice:   "8.00",
+				Currency:    "BRL",
 				Image:       "https://example.com/image.jpg",
 				Description: "Product description",
 				SellerID:    "seller_1",
@@ -127,6 +128,7 @@ func TestProductEntry(t *testing.T) {
 				"retailer_id": "sku_123",
 				"price": "10.00",
 				"sale_price": "8.00",
+				"currency": "BRL",
 				"image": "https://example.com/image.jpg",
 				"description": "Product description",
 				"seller_id": "seller_1"


### PR DESCRIPTION
### TL;DR

Added a `Currency` field to the `ProductRetailerInfo` struct to support multiple currencies in product information.

### What changed?

- Added a new `Currency` field to the `ProductRetailerInfo` struct in `flows/services.go`
- Updated the corresponding test in `flows/services_test.go` to include the currency field with a value of "BRL"

### Why make this change?

This change enables support for specifying the currency of product prices, which is essential for international e-commerce applications. Without this field, it would be impossible to determine which currency the price and sale price values are in, potentially causing confusion for users in different regions.